### PR TITLE
Remove 'Known Problems' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,3 @@ you are working with and a minimal example that shows the problem.
 Examples for the use of the plugin with different kinds of monad generalizations 
 are provided in the `examples` directory. All examples have their own separate 
 cabal file and offer a version of the code with and without the use of supermonads.
-
-## Known Problems
-
-* The `effect` example will not compile with GHC 8+, 
-  because the `effect-monad` package requires `base < 4.9`
-  but GHC 8+ delivers `base >= 4.9`.


### PR DESCRIPTION
`effect-monad` 0.7 no longer requires `base < 4.9`